### PR TITLE
[src] Make library init explicit

### DIFF
--- a/src/test/discriminant_test.go
+++ b/src/test/discriminant_test.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"math/big"
 	"testing"
+
 	"github.com/harmony-one/vdf/src/vdf_go"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBigNumEncoding(t *testing.T) {
@@ -23,6 +24,7 @@ func TestEntropyFromSeed(t *testing.T) {
 
 func TestDiscriminant(t *testing.T) {
 	seed := []byte{0xab, 0xcd}
+	vdf_go.Init()
 	n := vdf_go.CreateDiscriminant(seed, 2048)
 	s := fmt.Sprintf("%02x", vdf_go.EncodeBigIntBigEndian(n))
 	assert.Equal(t, "ffff550d4074f264c4db9fb6c4af4e4a1aa6d700b3cf3601388d37aea312fc9b512581a8fa6f3575ae3d34c6b12401838da34360678a2f43178c43c96a46a2bd682db7fa63085c1a65053e738b158efdc4d952c549e6891d87d2de794132869bb5cefcf28193359f182358692be7b864413ee985893565046cc165994fb18f49ca75a8ec65ba1ef7450c53210943fde31c5c553f882b5fdadd8f3c1baa85309b68bd02ba526d8a1aabe5dc0aaa483d0fe230e5c6c6165d7d79184646e2909076b0eea3926a9b17f184b61588c90e5175e3a99ab343bb97859c0cde75a607a6e46a94f95580521f8ebaeeb58e587b39434a218dbcecc5cd365932926990c84c84fe29", s, "they should be equal")

--- a/src/test/square_test.go
+++ b/src/test/square_test.go
@@ -4,14 +4,15 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"log"
 	"math/big"
 	"regexp"
 	"runtime"
 	"testing"
 	"time"
+
 	"github.com/harmony-one/vdf/src/vdf_go"
+	"github.com/stretchr/testify/assert"
 )
 
 func RepeatedSquare(x *vdf_go.ClassGroup, k int) *vdf_go.ClassGroup {
@@ -38,6 +39,7 @@ func TestTwoSquarePerformance(t *testing.T) {
 	for k := 0; k < 10; k++ {
 		seed := make([]byte, 32)
 		rand.Read(seed)
+		vdf_go.Init()
 		D := vdf_go.CreateDiscriminant(seed, 2048)
 		x := vdf_go.NewClassGroupFromAbDiscriminant(big.NewInt(2), big.NewInt(1), D)
 

--- a/src/vdf_go/discriminant.go
+++ b/src/vdf_go/discriminant.go
@@ -16,19 +16,23 @@ var odd_primes = primeLessThanN(1 << 16)
 var m = 8 * 3 * 5 * 7 * 11 * 13
 var residues = make([]int, 0, m)
 var sieve_info = make([]Pair, 0, len(odd_primes))
+var isLibraryReady = false
 
-func init() {
-	for x := 7; x < m; x += 8 {
-		if (x%3 != 0) && (x%5 != 0) && (x%7 != 0) && (x%11 != 0) && (x%13 != 0) {
-			residues = append(residues, x)
+func Init() {
+	if !isLibraryReady {
+		for x := 7; x < m; x += 8 {
+			if (x%3 != 0) && (x%5 != 0) && (x%7 != 0) && (x%11 != 0) && (x%13 != 0) {
+				residues = append(residues, x)
+			}
 		}
-	}
 
-	var odd_primes_above_13 = odd_primes[5:]
+		var odd_primes_above_13 = odd_primes[5:]
 
-	for i := 0; i < len(odd_primes_above_13); i++ {
-		prime := int64(odd_primes_above_13[i])
-		sieve_info = append(sieve_info, Pair{p: int64(prime), q: modExp(int64(m)%prime, prime-2, prime)})
+		for i := 0; i < len(odd_primes_above_13); i++ {
+			prime := int64(odd_primes_above_13[i])
+			sieve_info = append(sieve_info, Pair{p: int64(prime), q: modExp(int64(m)%prime, prime-2, prime)})
+		}
+		isLibraryReady = true
 	}
 }
 

--- a/src/vdf_go/proof_wesolowski.go
+++ b/src/vdf_go/proof_wesolowski.go
@@ -73,6 +73,7 @@ func GenerateVDF(seed []byte, iterations, int_size_bits int) ([]byte, []byte) {
 func GenerateVDFWithStopChan(seed []byte, iterations, int_size_bits int, stop <-chan struct{}) ([]byte, []byte) {
 	defer timeTrack(time.Now())
 
+	Init()
 	D := CreateDiscriminant(seed, int_size_bits)
 	x := NewClassGroupFromAbDiscriminant(big.NewInt(2), big.NewInt(1), D)
 
@@ -89,7 +90,7 @@ func VerifyVDF(seed, proof_blob []byte, iterations, int_size_bits int) bool {
 	defer timeTrack(time.Now())
 
 	int_size := (int_size_bits + 16) >> 4
-
+	Init()
 	D := CreateDiscriminant(seed, int_size_bits)
 	x := NewClassGroupFromAbDiscriminant(big.NewInt(2), big.NewInt(1), D)
 	y, _ := NewClassGroupFromBytesDiscriminant(proof_blob[:(2*int_size)], D)


### PR DESCRIPTION
This PR makes library initialization explicit, motivated by issues raised here https://github.com/harmony-one/harmony/issues/1562

and in the conventions of making `init` functions not resource intensive. 